### PR TITLE
Add ability to specify inherited permissions in base policy

### DIFF
--- a/lib/accessly/policy/base.rb
+++ b/lib/accessly/policy/base.rb
@@ -38,6 +38,10 @@ module Accessly
         self.class.model_scope
       end
 
+      # Specifies all the actors used in permission lookups.
+      # Override this method in child policy classes to specify
+      # other actors that the actor given in the initializer may
+      # inherit permissions from.
       def actors
         actor
       end

--- a/lib/accessly/policy/base.rb
+++ b/lib/accessly/policy/base.rb
@@ -38,6 +38,10 @@ module Accessly
         self.class.model_scope
       end
 
+      def actors
+        actor
+      end
+
       def unrestricted?
         false
       end
@@ -72,7 +76,7 @@ module Accessly
 
       def accessly_query
         @_accessly_query ||= begin
-          query = Accessly::Query.new(actor)
+          query = Accessly::Query.new(actors)
           query.on_segment(segment_id) unless segment_id.nil?
           query
         end

--- a/test/base_policy_inherited_actors_test.rb
+++ b/test/base_policy_inherited_actors_test.rb
@@ -1,0 +1,114 @@
+require "test_helper"
+require "accessly/policy/base"
+
+describe Accessly::Policy::Base do
+
+  class UserInGroupsPolicy < Accessly::Policy::Base
+
+    actions view: 1
+    actions_on_objects view: 1
+
+    def self.namespace
+      User.name
+    end
+
+    def self.model_scope
+      User.all
+    end
+
+    def actors
+      { User => actor.id, Group => actor.group.id }
+    end
+  end
+
+  it "uses the actors defined in the class for general permission lookups" do
+    group = Group.create!
+    user = User.create!(group: group)
+
+    UserInGroupsPolicy.new(user).view?.must_equal false
+
+    Accessly::PermittedAction.create!(
+      id: SecureRandom.uuid,
+      segment_id: -1,
+      actor: group,
+      action: 1,
+      object_type: String(User)
+    )
+
+    UserInGroupsPolicy.new(user).view?.must_equal true
+  end
+
+  it "uses the actors defined in the class for object permission lookups" do
+    group = Group.create!
+    user = User.create!(group: group)
+    other_user = User.create!
+
+    UserInGroupsPolicy.new(user).view?(other_user).must_equal false
+
+    Accessly::PermittedActionOnObject.create!(
+      id: SecureRandom.uuid,
+      segment_id: -1,
+      actor: group,
+      action: 1,
+      object_type: String(User),
+      object_id: other_user.id
+    )
+
+    UserInGroupsPolicy.new(user).view?(other_user).must_equal true
+  end
+
+  it "uses the actors defined in the class for list lookups" do
+    group = Group.create!
+    user = User.create!(group: group)
+    other_user = User.create!
+
+    UserInGroupsPolicy.new(user).view?(other_user).must_equal false
+
+    Accessly::PermittedActionOnObject.create!(
+      id: SecureRandom.uuid,
+      segment_id: -1,
+      actor: group,
+      action: 1,
+      object_type: String(User),
+      object_id: other_user.id
+    )
+
+    UserInGroupsPolicy.new(user).view.must_equal [other_user]
+  end
+
+  it "does not grant the additional actors permissions with #grant" do
+    group = Group.create!
+    user = User.create!(group: group)
+
+    UserInGroupsPolicy.new(user).grant(:view)
+
+    Accessly::PermittedAction.where(actor: user).exists?.must_equal true
+    Accessly::PermittedAction.where(actor: group).exists?.must_equal false
+  end
+
+  it "does not revoke the additional actors permissions with #revoke" do
+    group = Group.create!
+    user = User.create!(group: group)
+
+    Accessly::PermittedAction.create!(
+      id: SecureRandom.uuid,
+      segment_id: -1,
+      actor: user,
+      action: 1,
+      object_type: String(User)
+    )
+
+    Accessly::PermittedAction.create!(
+      id: SecureRandom.uuid,
+      segment_id: -1,
+      actor: group,
+      action: 1,
+      object_type: String(User)
+    )
+
+    UserInGroupsPolicy.new(user).revoke(:view)
+
+    Accessly::PermittedAction.where(actor: user).exists?.must_equal false
+    Accessly::PermittedAction.where(actor: group).exists?.must_equal true
+  end
+end

--- a/test/fixtures/group.rb
+++ b/test/fixtures/group.rb
@@ -1,2 +1,3 @@
 class Group < ActiveRecord::Base
+  has_many :users, inverse_of: :group
 end

--- a/test/fixtures/user.rb
+++ b/test/fixtures/user.rb
@@ -1,2 +1,3 @@
 class User < ActiveRecord::Base
+  belongs_to :group, inverse_of: :users
 end


### PR DESCRIPTION
## Why

The base policy accepts an `actor` in the initializer, but there's no way to specify other actors that `actor` may inherit permissions from. For example, a `User` may inherit permission from its `Group`s.

## What

This PR introduces an `actors` method which, by default, just returns the `actor`. However, developers can override it in a policy class to specify inherited actors.

When overriding it, you must use the format specified by `Accessly::Query` (meaning, either a single `ActiveRecord::Base` object or a hash containing `{ ModelClass => [ids], OtherModelClass => [other_ids] }`.