### PR TITLE
Add pgcrypto extension in test database schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    accessly (1.0.0)
+    accessly (1.0.1)
       activerecord (~> 5.0)
 
 GEM

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -1,4 +1,6 @@
 ActiveRecord::Schema.define(version: 1) do
+  ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto;")
+
   create_table :users, force: true do |t|
     t.column :name, :string
     t.column :admin, :boolean


### PR DESCRIPTION
# What

Make it so that this repo's tests run in CI. This adds the `pgcrypto` extension to the test database, which is the only requirement that wasn't being met.

# Caveats

I put this is the `schema.rb` file, which is technically a generated file. Is there a better place to put it?