### PR TITLE
Setup Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+services:
+  - postgresql
+cache: bundler
+rvm:
+  - 2.7
+  - 2.6
+gemfile:
+  - Gemfile
+before_script:
+  - psql -c 'create database aaa_test;' -U postgres
+before_install:
+  - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source "https://rubygems.org"
-ruby "2.6.5"
 
 gemspec


### PR DESCRIPTION
Setup Travis CI so that PRs from forked repositories will get CI run on them as well.
- Setup jobs to run with both Ruby 2.7 and Ruby 2.6