### PR TITLE
Updating rake to match the version for lessonly

### DIFF
--- a/accessly.gemspec
+++ b/accessly.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 5.0"
 
   spec.add_development_dependency "bundler", "~> 2.1"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "database_cleaner", "~> 1.8"
   spec.add_development_dependency "pg", "~> 1.0"


### PR DESCRIPTION
## Why?

Resolves [[sc-78189]](https://app.shortcut.com/lessonly/story/78189)

https://github.com/lessonly/accessly/security/dependabot/accessly.gemspec/rake/open

rake vulnerability found in accessly.gemspec on Feb 29, 2020
Remediation
Upgrade rake to version 12.3.3 or later. For example:

spec.add_dependency "rake", ">= 12.3.3"
or…
spec.add_development_dependency "rake", ">= 12.3.3"
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2020-8130
moderate severity
Vulnerable versions: <= 12.3.2
Patched version: 12.3.3
There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |.

## What?

Updates Rake to be the same version as the Lessonly project.

## Merge Instructions

Please **DO NOT** squash my commits when merging
